### PR TITLE
Fixes time rules incorrectly handling overflow

### DIFF
--- a/includes/Availability/Rule/AbstractCompositeTimeRule.php
+++ b/includes/Availability/Rule/AbstractCompositeTimeRule.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Aventura\Edd\Bookings\Availability\Rule;
+
+use \Aventura\Diary\Bookable\Availability\Timetable\Rule\TimeRangeRule;
+use \Aventura\Diary\DateTime\Duration;
+use \Aventura\Diary\DateTime\Period;
+use \Aventura\Diary\DateTime\Period\PeriodInterface;
+use \Aventura\Edd\Bookings\Availability\SessionRule\SessionRuleInterface;
+
+/**
+ * This variation of a TimeRangeRule uses multiple child rules to resolve `obeys()` checks.
+ *
+ * A period of time will obey a composite rule if it obeys at least one of the child rules. Implementors are only
+ * required to implement the `generateChildRules()` method. This class will take care of child rule caching for
+ * the first `getChildRules()` call. Subsequent changes to the upper and lower value is not recommended.
+ *
+ * @since [*next-version*]
+ */
+abstract class AbstractCompositeTimeRule extends TimeRangeRule implements SessionRuleInterface
+{
+
+    /**
+     * The child rules cache.
+     *
+     * @var array
+     */
+    protected $childRules = null;
+
+    /**
+     * Gets the child rules.
+     *
+     * @return array
+     */
+    public function getChildRules()
+    {
+        if (is_null($this->childRules)) {
+            $this->childRules = $this->generateChildRules();
+        }
+
+        return $this->childRules;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function obeys(PeriodInterface $period)
+    {
+        foreach ($this->getChildRules() as $rule) {
+            if ($rule->obeys($period)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function generateSessionsForRange(PeriodInterface $range, Duration $duration)
+    {
+        // Save negation setting and disable it temporarily
+        $negation = $this->isNegated();
+        $this->setNegation(false);
+        // Get range info
+        $start = $range->getStart();
+        $end = $range->getEnd();
+        $date = $range->getStart()->getDate();
+        // Array to build and return
+        $sessions = array();
+        // Create first session
+        $current = new Period($date->copy()->plus($this->getLower()), $duration);
+        // Iterate until the current period is before the range end
+        while ($current->getEnd()->isBefore($end, true)) {
+            // If the current period is inside the range and obeys this rule
+            if ($current->getStart()->isAfter($start, true) && $this->obeys($current)) {
+                // Add it to the resulting array
+                $sessions[$current->getStart()->getTimestamp()] = $current->copy();
+            }
+            // Increment by the given duration
+            $current->getStart()->plus($duration);
+        }
+        // Restore negation
+        $this->setNegation($negation);
+        // Return results
+        return $sessions;
+    }
+
+    /**
+     * Generates the child rules.
+     *
+     * @return array
+     */
+    abstract public function generateChildRules();
+
+}

--- a/includes/Availability/Rule/AllWeekTimeRule.php
+++ b/includes/Availability/Rule/AllWeekTimeRule.php
@@ -9,7 +9,7 @@ use \Aventura\Diary\DateTime\Day;
  *
  * @author Miguel Muscat <miguelmuscat93@gmail.com>
  */
-class AllWeekTimeRule extends DotwTimeRule
+class AllWeekTimeRule extends CompositeDotwTimeRule
 {
     
     public function __construct($timeLower, $timeUpper)

--- a/includes/Availability/Rule/CompositeDotwTimeRule.php
+++ b/includes/Availability/Rule/CompositeDotwTimeRule.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Aventura\Edd\Bookings\Availability\Rule;
+
+use \Aventura\Diary\DateTime\DateTimeInterface;
+
+/**
+ * A composite time rule made up of a set of DotwTimeRules
+ *
+ * @since [*next-version*]
+ */
+class CompositeDotwTimeRule extends AbstractCompositeTimeRule
+{
+
+    /**
+     * The lower dotw index.
+     *
+     * @var int
+     */
+    protected $lowerDotw;
+
+    /**
+     * The upper dotw index.
+     *
+     * @var int
+     */
+    protected $upperDotw;
+
+    /**
+     * Constructor.
+     *
+     * @param int $lowerDotw Lower dotw index.
+     * @param int $upperDotw Upper dotw index.
+     * @param DateTimeInterface $startTime Lower day time.
+     * @param DateTimeInterface $endTime Upper day time.
+     */
+    public function __construct($lowerDotw, $upperDotw, DateTimeInterface $startTime, DateTimeInterface $endTime)
+    {
+        parent::__construct($startTime, $endTime);
+        $this->lowerDotw = $lowerDotw;
+        $this->upperDotw = $upperDotw;
+    }
+
+    /**
+     * Gets the range's lower day of the week.
+     *
+     * @return int The dotw index.
+     */
+    public function getLowerDotw()
+    {
+        return $this->lowerDotw;
+    }
+
+    /**
+     * Gets the range's upper day of the week.
+     *
+     * @return int The dotw index.
+     */
+    public function getUpperDotw()
+    {
+        return $this->upperDotw;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function generateChildRules()
+    {
+        $rules = array();
+        for ($i = $this->getLowerDotw(); $i <= $this->getUpperDotw(); $i++) {
+            $rules[] = new DotwTimeRule($i, $this->getLower(), $this->getUpper());
+        }
+
+        return $rules;
+    }
+
+}

--- a/includes/Availability/Rule/DotwTimeRule.php
+++ b/includes/Availability/Rule/DotwTimeRule.php
@@ -123,7 +123,7 @@ class DotwTimeRule extends AbstractCompositeTimeRule
             ));
         } else {
             return array_filter(array(
-                $this->createChildRule($prevDotw, Duration::SECONDS_IN_DAY + $lower, Duration::SECONDS_IN_DAY + $lower)
+                $this->createChildRule($prevDotw, Duration::SECONDS_IN_DAY + $lower, Duration::SECONDS_IN_DAY + $upper)
             ));
         }
     }

--- a/includes/Availability/Rule/DotwTimeRule.php
+++ b/includes/Availability/Rule/DotwTimeRule.php
@@ -31,7 +31,11 @@ class DotwTimeRule extends AbstractCompositeTimeRule
      */
     public function __construct($dotw, DateTime $timeLower, DateTime $timeUpper)
     {
-        parent::__construct($timeLower, $timeUpper);
+        if ($timeLower->isBefore($timeUpper)) {
+            parent::__construct($timeLower, $timeUpper);
+        } else {
+            parent::__construct($timeUpper, $timeLower);
+        }
         $this->dotw = $dotw;
     }
 

--- a/includes/Availability/Rule/DotwTimeRule.php
+++ b/includes/Availability/Rule/DotwTimeRule.php
@@ -108,13 +108,20 @@ class DotwTimeRule extends AbstractCompositeTimeRule
     protected function generateNegativeOverflowRules()
     {
         $dotw = $this->getDotw();
+        $prevDotw = $this->clampDotw($dotw - 1);
         $lower = $this->getLower()->getTimestamp();
         $upper = $this->getUpper()->getTimestamp();
 
-        return array_filter(array(
-            $this->createChildRule($this->clampDotw($dotw - 1), Duration::SECONDS_IN_DAY + $lower, Duration::SECONDS_IN_DAY),
-            $this->createChildRule($dotw, 0, $upper)
-        ));
+        if ($upper >= 0) {
+            return array_filter(array(
+                $this->createChildRule($prevDotw, Duration::SECONDS_IN_DAY + $lower, Duration::SECONDS_IN_DAY),
+                $this->createChildRule($dotw, 0, $upper)
+            ));
+        } else {
+            return array_filter(array(
+                $this->createChildRule($prevDotw, Duration::SECONDS_IN_DAY + $lower, Duration::SECONDS_IN_DAY + $lower)
+            ));
+        }
     }
 
     /**
@@ -125,13 +132,20 @@ class DotwTimeRule extends AbstractCompositeTimeRule
     protected function generatePositiveOverflowRules()
     {
         $dotw = $this->getDotw();
+        $nextDotw = $this->clampDotw($dotw + 1);
         $lower = $this->getLower()->getTimestamp();
         $upper = $this->getUpper()->getTimestamp();
 
-        return array_filter(array(
-            $this->createChildRule($dotw, $lower, Duration::SECONDS_IN_DAY),
-            $this->createChildRule($this->clampDotw($dotw + 1), 0, $upper - Duration::SECONDS_IN_DAY)
-        ));
+        if ($lower <= Duration::SECONDS_IN_DAY) {
+            return array_filter(array(
+                $this->createChildRule($dotw, $lower, Duration::SECONDS_IN_DAY),
+                $this->createChildRule($nextDotw, 0, $upper - Duration::SECONDS_IN_DAY)
+            ));
+        } else {
+            return array_filter(array(
+                $this->createChildRule($nextDotw, $lower - Duration::SECONDS_IN_DAY, $upper - Duration::SECONDS_IN_DAY)
+            ));
+        }
     }
 
 }

--- a/includes/Availability/Rule/DotwTimeRule.php
+++ b/includes/Availability/Rule/DotwTimeRule.php
@@ -2,64 +2,136 @@
 
 namespace Aventura\Edd\Bookings\Availability\Rule;
 
-use \Aventura\Diary\Bookable\Availability\Timetable\Rule\DotwTimeRangeRule;
 use \Aventura\Diary\DateTime;
+use \Aventura\Diary\DateTime\Day;
 use \Aventura\Diary\DateTime\Duration;
-use \Aventura\Diary\DateTime\Period;
-use \Aventura\Diary\DateTime\Period\PeriodInterface;
-use \Aventura\Edd\Bookings\Availability\SessionRule\SessionRuleInterface;
 
 /**
- * Description of GroupDotwTimeRule
+ * A time rule for a day of the week.
+ *
+ * This class differs from SimpleDotwTimeRule in that it caters for time overflow by creating multiple
+ * SimpleDotwTimeRule instances such that times can overflow into other non-obedient days of the week but
+ * still match this rule.
  *
  * @author Miguel Muscat <miguelmuscat93@gmail.com>
  */
-class DotwTimeRule extends DotwTimeRangeRule implements SessionRuleInterface
+class DotwTimeRule extends AbstractCompositeTimeRule
 {
 
     /**
-     * {@inheritdoc}
-     * 
-     * @param integer $dotwLower The range lower day of the week index.
-     * @param integer $dotwUpper The range upper day of the week index.
-     * @param DateTime $timeLower The range lower datetime.
-     * @param DateTime $timeUpper The range upper datetime.
+     * The range's dotw, 1-based.
+     *
+     * @see Day
+     * @var int
      */
-    public function __construct($dotwLower, $dotwUpper, $timeLower, $timeUpper)
+    protected $dotw;
+
+    /**
+     * Constructs a new instance.
+     */
+    public function __construct($dotw, DateTime $timeLower, DateTime $timeUpper)
     {
-        parent::__construct($dotwLower, $dotwUpper, $timeLower, $timeUpper);
+        parent::__construct($timeLower, $timeUpper);
+        $this->dotw = $dotw;
     }
-    
+
+    /**
+     * Gets the day of the week.
+     *
+     * @see Day
+     * @return int The day of the week (1-based).
+     */
+    public function getDotw()
+    {
+        return $this->dotw;
+    }
+
+    /**
+     * Clamps a dotw index between 1 and 7.
+     *
+     * @param int $dotw
+     * @return int
+     */
+    protected function clampDotw($dotw)
+    {
+        // Normalize negative numbers into positive range
+        $nDotw = ($dotw <= 0)
+            ? 7 - $dotw
+            : $dotw;
+
+        return (($nDotw - 1) % 7) + 1;
+    }
+
     /**
      * {@inheritdoc}
      */
-    public function generateSessionsForRange(PeriodInterface $range, Duration $duration)
+    public function generateChildRules()
     {
-        // Save negation setting and disable it temporarily
-        $negation = $this->isNegated();
-        $this->setNegation(false);
-        // Get range info
-        $start = $range->getStart();
-        $end = $range->getEnd();
-        $date = $range->getStart()->getDate();
-        // Array to build and return
-        $sessions = array();
-        // Create first session
-        $current = new Period($date->copy()->plus($this->getLower()), $duration);
-        // Iterate until the current period is before the range end
-        while ($current->getEnd()->isBefore($end, true)) {
-            // If the current period is inside the range and obeys this rule
-            if ($current->getStart()->isAfter($start, true) && $this->obeys($current)) {
-                // Add it to the resulting array
-                $sessions[$current->getStart()->getTimestamp()] = $current->copy();
-            }
-            // Increment by the given duration
-            $current->getStart()->plus($duration);
+        // Pre-fetch values
+        $lower = $this->getLower()->getTimestamp();
+        $upper = $this->getupper()->getTimestamp();
+
+        if ($lower < 0) {
+            // Negative overflow
+            return $this->generateNegativeOverflowRules();
+        } else if ($upper > Duration::SECONDS_IN_DAY) {
+            // Positive overflow
+            return $this->generatePositiveOverflowRules();
         }
-        // Restore negation
-        $this->setNegation($negation);
-        // Return results
-        return $sessions;
+
+        // No overflow - replicate the parent rule
+        return array(
+            $this->createChildRule($this->getDotw(), $lower, $upper)
+        );
+    }
+
+    /**
+     * Creates a child rule.
+     *
+     * @param int $dotw The DOTW index.
+     * @param int $lower The lower time.
+     * @param int $upper The upper time.
+     * @return SimpleDotwTimeRule The rule instance or null if the rule could not be created.
+     */
+    protected function createChildRule($dotw, $lower, $upper)
+    {
+        return ($lower !== $upper)
+            ? new SimpleDotwTimeRule($dotw, $dotw, new DateTime($lower), new DateTime($upper))
+            : null;
+    }
+
+    /**
+     * Generates child rules in the event of negative time overflow.
+     *
+     * @return SimpleDotwTimeRule[]
+     */
+    protected function generateNegativeOverflowRules()
+    {
+        $dotw = $this->getDotw();
+        $lower = $this->getLower()->getTimestamp();
+        $upper = $this->getUpper()->getTimestamp();
+
+        return array_filter(array(
+            $this->createChildRule($this->clampDotw($dotw - 1), Duration::SECONDS_IN_DAY + $lower, Duration::SECONDS_IN_DAY),
+            $this->createChildRule($dotw, 0, $upper)
+        ));
+    }
+
+    /**
+     * Generates child rules in the event of positive time overflow.
+     *
+     * @return SimpleDotwTimeRule[]
+     */
+    protected function generatePositiveOverflowRules()
+    {
+        $dotw = $this->getDotw();
+        $lower = $this->getLower()->getTimestamp();
+        $upper = $this->getUpper()->getTimestamp();
+
+        return array_filter(array(
+            $this->createChildRule($dotw, $lower, Duration::SECONDS_IN_DAY),
+            $this->createChildRule($this->clampDotw($dotw + 1), 0, $upper - Duration::SECONDS_IN_DAY)
+        ));
     }
 
 }

--- a/includes/Availability/Rule/SimpleDotwTimeRule.php
+++ b/includes/Availability/Rule/SimpleDotwTimeRule.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Aventura\Edd\Bookings\Availability\Rule;
+
+use \Aventura\Diary\Bookable\Availability\Timetable\Rule\DotwTimeRangeRule;
+use \Aventura\Diary\DateTime;
+use \Aventura\Diary\DateTime\Duration;
+use \Aventura\Diary\DateTime\Period;
+use \Aventura\Diary\DateTime\Period\PeriodInterface;
+use \Aventura\Edd\Bookings\Availability\SessionRule\SessionRuleInterface;
+
+/**
+ * A rule for matching a day of the week with a specific time range.
+ *
+ * Unlike DotwTimeRule, this rule does not cater for times that over flow into other days of the week, which
+ * could potentially result in unwanted behaviour, especially when the time values are timezone shifted.
+ *
+ * @since [*next-version*]
+ */
+class SimpleDotwTimeRule extends DotwTimeRangeRule implements SessionRuleInterface
+{
+
+    /**
+     * {@inheritdoc}
+     *
+     * @param integer $dotwLower The range lower day of the week index.
+     * @param integer $dotwUpper The range upper day of the week index.
+     * @param DateTime $timeLower The range lower datetime.
+     * @param DateTime $timeUpper The range upper datetime.
+     */
+    public function __construct($dotwLower, $dotwUpper, $timeLower, $timeUpper)
+    {
+        parent::__construct($dotwLower, $dotwUpper, $timeLower, $timeUpper);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function generateSessionsForRange(PeriodInterface $range, Duration $duration)
+    {
+        // Save negation setting and disable it temporarily
+        $negation = $this->isNegated();
+        $this->setNegation(false);
+        // Get range info
+        $start = $range->getStart();
+        $end = $range->getEnd();
+        $date = $range->getStart()->getDate();
+        // Array to build and return
+        $sessions = array();
+        // Create first session
+        $current = new Period($date->copy()->plus($this->getLower()), $duration);
+        // Iterate until the current period is before the range end
+        while ($current->getEnd()->isBefore($end, true)) {
+            // If the current period is inside the range and obeys this rule
+            if ($current->getStart()->isAfter($start, true) && $this->obeys($current)) {
+                // Add it to the resulting array
+                $sessions[$current->getStart()->getTimestamp()] = $current->copy();
+            }
+            // Increment by the given duration
+            $current->getStart()->plus($duration);
+        }
+        // Restore negation
+        $this->setNegation($negation);
+        // Return results
+        return $sessions;
+    }
+
+}

--- a/includes/Availability/Rule/SingleDotwTimeRule.php
+++ b/includes/Availability/Rule/SingleDotwTimeRule.php
@@ -17,17 +17,16 @@ class SingleDotwTimeRule extends DotwTimeRule implements SessionRuleInterface
      * Day of the week index.
      */
     const DOTW = 0;
-    
+
     /**
      * {@inheritdoc}
      * 
-     * @param integer $dotw The range day of the week index.
      * @param DateTime $timeLower The range lower datetime.
      * @param DateTime $timeUpper The range upper datetime.
      */
     public function __construct($timeLower, $timeUpper)
     {
-        parent::__construct(static::DOTW, static::DOTW, $timeLower, $timeUpper);
+        parent::__construct(static::DOTW, $timeLower, $timeUpper);
     }
 
 }

--- a/includes/Availability/Rule/WeekdaysTimeRule.php
+++ b/includes/Availability/Rule/WeekdaysTimeRule.php
@@ -9,9 +9,9 @@ use \Aventura\Diary\DateTime\Day;
  *
  * @author Miguel Muscat <miguelmuscat93@gmail.com>
  */
-class WeekdaysTimeRule extends DotwTimeRule
+class WeekdaysTimeRule extends CompositeDotwTimeRule
 {
-    
+
     public function __construct($timeLower, $timeUpper)
     {
         parent::__construct(Day::MONDAY, Day::FRIDAY, $timeLower, $timeUpper);

--- a/includes/Availability/Rule/WeekendTimeRule.php
+++ b/includes/Availability/Rule/WeekendTimeRule.php
@@ -9,9 +9,9 @@ use \Aventura\Diary\DateTime\Day;
  *
  * @author Miguel Muscat <miguelmuscat93@gmail.com>
  */
-class WeekendTimeRule extends DotwTimeRule
+class WeekendTimeRule extends CompositeDotwTimeRule
 {
-    
+
     public function __construct($timeLower, $timeUpper)
     {
         parent::__construct(Day::SATURDAY, Day::SUNDAY, $timeLower, $timeUpper);

--- a/includes/CustomPostType/ServicePostType.php
+++ b/includes/CustomPostType/ServicePostType.php
@@ -442,7 +442,7 @@ class ServicePostType extends CustomPostType
         $end = $rangeEnd + $service->getMinSessionLength();
         // Create Period range object
         $duration = new Duration(abs($end - $start->getTimestamp() + 1));
-        $range = new Period($start, $duration);
+        $range = new Period($this->getPlugin()->utcTimeToServerTime($start), $duration);
         // Generate sessions and return
         $response['sessions'] = $service->generateSessionsForRange($range);
         $response['range'] = array(


### PR DESCRIPTION
Incorporates a fix for #10, where the day-of-the-week time rules (Mon-Sun, All Week, Weekdays and Weekends) were incorrectly handling overflows.

Overflow would occur when the server timezone caused session times to get offset into a DOTW that did not obey the rule. The solution involves created child rules internally when overflow is detected so that these sessions obey the parent rule.

As a consequence, this also fixes the bug where the server timezone would clip out sessions at the beginning or end of a month.