### PR TITLE
Fixes session picker output from `[purchase_link]` shortcode (EDDBOOK-35)

### DIFF
--- a/includes/Controller/ServiceController.php
+++ b/includes/Controller/ServiceController.php
@@ -85,21 +85,22 @@ class ServiceController extends ModelCptControllerAbstract
      * @return array
      */
     protected function enqueueFrontendAssets(array $assets, AssetsController $c) {
-        if (is_single() && get_post_type() === $this->getPostType()->getSlug()) {
-            $assets = array_merge($assets, array(
-                'eddbk.js.service.frontend',
-                'eddbk.css.service.frontend',
-                'jquery-ui-datepicker'
-            ));
-        }
+        // Always enqueue these on the frontend
+        $outputAssets = array_merge($assets, array(
+            'eddbk.js.service.frontend',
+            'eddbk.css.service.frontend',
+            'jquery-ui-datepicker'
+        ));
+        // Assets for the EDD checkout page
         if (edd_is_checkout()) {
-            $assets = array_merge($assets, array(
+            $outputAssets = array_merge($assets, array(
                 'eddbk.js.service.checkout',
                 'eddbk.css.service.checkout',
                 'jquery-ui-datepicker'
             ));
         }
-        return $assets;
+
+        return $outputAssets;
     }
 
     /**

--- a/includes/CustomPostType/ServicePostType.php
+++ b/includes/CustomPostType/ServicePostType.php
@@ -101,6 +101,8 @@ class ServicePostType extends CustomPostType
         if ($id === null) {
             $id = get_the_ID();
         }
+        // Check if the render process is triggered by a shortcode
+        $fromShortcode = isset($args['edd_bk_from_shortcode']);
         // Get booking options from args param
         $bookingOptions = isset($args['booking_options'])
                 ? $args['booking_options']
@@ -115,7 +117,9 @@ class ServicePostType extends CustomPostType
                 remove_filter( 'edd_purchase_download_form', 'edd_free_downloads_download_form', 200, 2 );
             }
             $renderer = new FrontendRenderer($service);
-            echo $renderer->render();
+            echo $renderer->render(array(
+                'override' => $fromShortcode
+            ));
         }
     }
     
@@ -578,6 +582,10 @@ class ServicePostType extends CustomPostType
             $bookingOptions = trim(strtolower($atts['booking_options']));
             $out['booking_options'] = !in_array($bookingOptions, array('no', 'off', 'false', '0'));
         }
+
+        // Add an indication that we are rendering from a shortcode
+        $out['edd_bk_from_shortcode'] = true;
+
         return $out;
     }
 

--- a/includes/Renderer/FrontendRenderer.php
+++ b/includes/Renderer/FrontendRenderer.php
@@ -17,14 +17,17 @@ class FrontendRenderer extends RendererAbstract
     {
         /* @var $service Service */
         $service = $this->getObject();
-        $fromShortcode = false;
-        // Guard output
-        if (!$service->getBookingsEnabled() || (!is_single() && !$service->getMultiViewOutput() && !$fromShortcode)) {
-            return '';
+        $override = isset($data['override'])
+            ? !!$data['override']
+            : false;
+        // Check if bookings enabled and can output on this page
+        if ($service->getBookingsEnabled() && (is_single() || $service->getMultiViewOutput() || $override)) {
+            return eddBookings()->renderView('Frontend.Download.SessionPicker', array(
+                'id' => $service->getId()
+            ));
         }
-        return eddBookings()->renderView('Frontend.Download.SessionPicker', array(
-            'id' => $service->getId()
-        ));
+
+        return '';
     }
 
 }

--- a/includes/Renderer/FrontendRenderer.php
+++ b/includes/Renderer/FrontendRenderer.php
@@ -22,10 +22,9 @@ class FrontendRenderer extends RendererAbstract
         if (!$service->getBookingsEnabled() || (!is_single() && !$service->getMultiViewOutput() && !$fromShortcode)) {
             return '';
         }
-        ob_start();
-        ?>
-        <div class="edd-bk-service-session-picker" data-service="<?php echo esc_attr($service->getId()); ?>"></div>
-        <?php return ob_get_clean();
+        return eddBookings()->renderView('Frontend.Download.SessionPicker', array(
+            'id' => $service->getId()
+        ));
     }
 
 }

--- a/views/Frontend/Download/SessionPicker.php
+++ b/views/Frontend/Download/SessionPicker.php
@@ -1,0 +1,1 @@
+<div class="edd-bk-service-session-picker" data-service="<?php echo esc_attr($data['id']); ?>"></div>


### PR DESCRIPTION
Incorporates a solution for #13 

Fixes the bug where output of the session picker from the `[purchase_link]` shortcode would only occur on Download pages.

The shortcode is now detected and will override such checks so that the session picker can be injected wherever the shortcode is used. The `booking_options` shortcode parameter has not been modified.